### PR TITLE
Set `Measure` as subtype of `AbstractType`

### DIFF
--- a/src/integration.jl
+++ b/src/integration.jl
@@ -151,7 +151,7 @@ function measure(f,dom::AbstractDomain,degree)
     Measure(mesh,f,dom,degree)
 end
 
-struct Measure{A,B,C,D}
+struct Measure{A,B,C,D} <: GT.AbstractType
     mesh::A
     quadrature_rule::B
     domain::C


### PR DESCRIPTION
@fverdugo this is an easy one. It closes #91.

https://github.com/fverdugo/GalerkinToolkit.jl/blob/9993597956eafb4fed46f24edf1c806e0bb5cf93/src/integration.jl#L154

